### PR TITLE
Allow any resource to be _dynamic not just raw

### DIFF
--- a/defaults/android/android-lint.xml
+++ b/defaults/android/android-lint.xml
@@ -56,7 +56,7 @@
     <issue id="UnusedIds" severity="error" />
     <issue id="UnusedNamespace" severity="error" />
     <issue id="UnusedResources" severity="error">
-        <ignore regexp="The resource R.raw..*_dynamic.* appears to be unused" />
+        <ignore regexp=".*_dynamic.*" />
     </issue>
     <issue id="UseCompoundDrawables" severity="warning" />
     <issue id="UselessLeaf" severity="error" />


### PR DESCRIPTION
With this rule we were only allowing raw dynamic resources. By changing it we allow any _dynamic resource.