### PR TITLE
Set ObsoletSdkInt as error

### DIFF
--- a/defaults/android/android-lint.xml
+++ b/defaults/android/android-lint.xml
@@ -50,6 +50,7 @@
     <issue id="MergeRootFrame" severity="error" />
     <issue id="NestedWeights" severity="error" />
     <issue id="ObsoleteLayoutParam" severity="error" />
+    <issue id="ObsoleteSdkInt" severity="error" />
     <issue id="Overdraw" severity="warning" />
     <issue id="Recycle" severity="error" />
     <issue id="TooDeepLayout" severity="error" />


### PR DESCRIPTION
Suggestion is because it help us to remove those hacks that everyone forget to remove after upgrading the `minSdkVersion` of the project.

**Note:** I don't know what happens if you set different minSdkVersion in a specific buildType just to set 21 as minimum to use instant run from the IDE. Is it gonna fail on your CI server? Should we use different rules for debug/release?

Example:
```
if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.HONEYCOMB) {
```

Docs:
```
ObsoleteSdkInt
--------------
Summary: Obsolete SDK_INT Version Check

Priority: 6 / 10
Severity: Warning
Category: Performance

This check flags version checks that are not necessary, because the
minSdkVersion (or surrounding known API level) is already at least as high as
the version checked for.
```