### PR TITLE
Exclude deeplinks.xml from MissingTranslation Android Lint check

### DIFF
--- a/defaults/android/android-lint.xml
+++ b/defaults/android/android-lint.xml
@@ -100,6 +100,7 @@
     <issue id="ExtraTranslation" severity="error" />
     <issue id="MissingTranslation" severity="error">
         <ignore path="**/strings_by_country.xml" />
+        <ignore path="**/deeplinks.xml" />
     </issue>
     <issue id="RtlHardcoded" severity="ignore" />
     <issue id="RtlSymmetry" severity="ignore" />


### PR DESCRIPTION
Add this file in order to put there all deep links from a single project.
The exclusion is to prevent adding the XML attribute `translatable="false"` to each resource in that file.